### PR TITLE
Add form schema types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This option does not require your app to product any user interface. Instead, yo
 schema that the Chec Dashboard uses to display a form:
 
 ```ts
-import { createSDK, ConfigSDK } from '@chec/integration-configuration-sdk';
+import { createSDK, SchemaFieldTypes } from '@chec/integration-configuration-sdk';
 
 (async () => {
   const sdk = await createSDK();
@@ -45,7 +45,7 @@ import { createSDK, ConfigSDK } from '@chec/integration-configuration-sdk';
   sdk.setSchema([
     {
       key: 'name',
-      type: 'short_text',
+      type: SchemaFieldTypes.ShortText,
       label: 'Your name',
     },
   ]);
@@ -60,6 +60,8 @@ app. As the user fills in the form, the integration config is updated as usual.
 You can register an event handler that is called when the configuration changes:
 
 ```ts
+import { createSDK } from '@chec/integration-configuration-sdk';
+
 (async () => {
   const sdk = await createSDK();
 
@@ -72,7 +74,7 @@ You can register an event handler that is called when the configuration changes:
 You can render buttons and watch for clicks:
 
 ```ts
-import { createSDK, ConfigSDK } from '@chec/integration-configuration-sdk';
+import { createSDK, SchemaFieldTypes } from '@chec/integration-configuration-sdk';
 
 (async () => {
   const sdk = await createSDK();
@@ -80,7 +82,7 @@ import { createSDK, ConfigSDK } from '@chec/integration-configuration-sdk';
   sdk.setSchema([
     {
       key: 'my_button',
-      type: 'button',
+      type: SchemaFieldTypes.Button,
       label: 'Click me',
     },
   ]);
@@ -95,6 +97,8 @@ You can also set config attributes directly using `setConfig`. Configuration set
 configuration.
 
 ```ts
+import { createSDK } from '@chec/integration-configuration-sdk';
+
 (async () => {
   const sdk = await createSDK();
 
@@ -103,6 +107,57 @@ configuration.
   });
 })();
 ```
+
+#### Using typescript to ensure form schema matches configuration
+
+This SDK provides types for form schema to help create valid form schemas for the Chec Dashboard. Additionally, you can
+provide a type definition for your configuration to perform type checking on the schema to ensure it matches the
+configuration you're expecting. For example, say you want to configure your integration with the following config:
+
+```ts
+export default interface MyIntegrationConfiguration {
+  customerMessage: string
+}
+```
+
+You may choose to create this in it's own file at the root of the project so it can be shared by the configuration app
+and the integration, that will have access to the config with `(await context.integration()).config`.
+
+Then you can create a schema like so:
+
+```ts
+import { Schema, SchemaFieldTypes } from '@chec/integration-configuration-sdk';
+import MyIntegrationConfiguration from '../config';
+
+const schema: Schema<MyIntegrationConfiguration> = [
+  {
+    key: 'customerMessage',
+    label: 'Message to display to the customer',
+    type: SchemaFieldTypes.ShortText,
+  }
+];
+```
+
+Typescript with throw an error if the value for `key` does not exist in your configuration interface, avoiding potential
+typos and mistakes. Additionally, you can ensure the schema matches your configuration only when you set it:
+
+```ts
+import { createSDK } from '@chec/integration-configuration-sdk';
+import MyIntegrationConfiguration from '../config';
+
+(async () => {
+  const sdk = await createSDK();
+
+  sdk.setSchema<MyIntegrationConfiguration>([
+    {
+      key: 'customerMessage',
+      label: 'Message to display to the customer',
+      type: SchemaFieldTypes.ShortText,
+    }
+  ]);
+})();
+```
+
 
 ### "Frame" option
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,15 @@
 import Postmate from 'postmate';
+export var SchemaFieldTypes;
+(function (SchemaFieldTypes) {
+    SchemaFieldTypes["ShortText"] = "short_text";
+    SchemaFieldTypes["LongText"] = "long_text";
+    SchemaFieldTypes["Number"] = "number";
+    SchemaFieldTypes["Wysiwyg"] = "wysiwyg";
+    SchemaFieldTypes["Boolean"] = "boolean";
+    SchemaFieldTypes["Select"] = "select";
+    SchemaFieldTypes["Button"] = "button";
+    SchemaFieldTypes["Link"] = "link";
+})(SchemaFieldTypes || (SchemaFieldTypes = {}));
 /**
  * Manages events broadcast from the dashboard and allows for attaching handlers to trigger from those events
  */

--- a/index.ts
+++ b/index.ts
@@ -1,20 +1,45 @@
 import Postmate, { ChildAPI } from 'postmate';
 
 /**
- * Represents the minimum information required for a field to be displayed in the Chec dashboard
+ * Represents the integration configuration that will eventually be saved against the integration record
  */
-export interface BaseField {
-  key: string,
-  type: string,
-  label: string,
+type Config = object;
+
+export enum SchemaFieldTypes {
+  ShortText = 'short_text',
+  LongText = 'long_text',
+  Number = 'number',
+  Wysiwyg = 'wysiwyg',
+  Boolean = 'boolean',
+  Select = 'select',
+  Button = 'button',
+  Link = 'link',
 }
+
+export interface SchemaItem<T = Config> {
+  default?: string|boolean|number|Array<string>
+  description?: string
+  disabled?: boolean
+  key: keyof T
+  label: string
+  required?: boolean
+  type: SchemaFieldTypes
+}
+
+export interface SelectSchemaItem<T = Config> extends SchemaItem<T> {
+  multiselect: boolean
+  options: Array<{ value: string, label: string }>
+  type: SchemaFieldTypes.Select,
+}
+
+export type Schema<T = Config> = Array<SchemaItem<T>|SelectSchemaItem<T>>
 
 /**
  * Represents an event relayed to the SDK from the dashboard
  */
-interface DashboardEvent {
+interface DashboardEvent<T = Config> {
   event: string,
-  field: BaseField|null,
+  field: SchemaItem<T>|null,
   payload: any,
 }
 
@@ -43,14 +68,9 @@ class EventBus {
 }
 
 /**
- * Represents the integration configuration that will eventually be saved against the integration record
- */
-export type Config = object;
-
-/**
  * The expected type of handler used when registered events to handle changes in integration configuration
  */
-export type ConfigWatcher = (config: Config) => void;
+type ConfigWatcher<T = Config> = (config: T) => void;
 
 /**
  * Represents a connection with the Chec dashboard when this app is rendered within the Chec dashboard, and provides
@@ -165,7 +185,7 @@ export class ConfigSDK {
   /**
    * Update the form schema that the Chec dashboard will use to render a configuration form to the user.
    */
-  setSchema(schema: Array<object>) {
+  setSchema<T = Config>(schema: Schema<T>) {
     this.parent.emit('set-schema', schema);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -81,12 +81,15 @@ export class ConfigSDK {
   eventBus: EventBus;
   config: Config;
   configWatchers: Array<ConfigWatcher>
+  editMode: boolean
 
   constructor(childApi: ChildAPI, eventBus: EventBus) {
     this.parent = childApi;
     this.eventBus = eventBus;
     // @ts-ignore
     this.config = childApi.model.config || {};
+    // @ts-ignore
+    this.editMode = Boolean(childApi.model.editMode);
     this.configWatchers = [];
 
     this.eventBus.pushHandler((event: DashboardEvent) => {


### PR DESCRIPTION
I made the mistake of mislabelling a key in my form schema - it didn't match what I expected from config in the integration. This should fix that if we use the typescript generics properly :slightly_smiling_face: