### PR TITLE
Convert whole config SDK to be a generic relying on a configuration definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ import { createSDK } from '@chec/integration-configuration-sdk';
 import MyIntegrationConfiguration from '../config';
 
 (async () => {
-  const sdk = await createSDK();
+  const sdk = await createSDK<MyIntegrationConfiguration>();
 
-  sdk.setSchema<MyIntegrationConfiguration>([
+  sdk.setSchema([
     {
       key: 'customerMessage',
       label: 'Message to display to the customer',

--- a/index.js
+++ b/index.js
@@ -35,11 +35,14 @@ export class ConfigSDK {
     constructor(childApi, eventBus) {
         this.parent = childApi;
         this.eventBus = eventBus;
+        this.configWatchers = [];
+        // Fill in some defaults provided by the dashboard through Postmate. The ts-ignores are here as the Postmate types
+        // provided by the community don't include a definition for `childApi.model`, maybe because it's not completely
+        // clear if this is intended to be a public API by Postmate.
         // @ts-ignore
         this.config = childApi.model.config || {};
         // @ts-ignore
         this.editMode = Boolean(childApi.model.editMode);
-        this.configWatchers = [];
         this.eventBus.pushHandler((event) => {
             if (event.event !== 'set-config') {
                 return;
@@ -120,6 +123,9 @@ export class ConfigSDK {
     }
     /**
      * Update the form schema that the Chec dashboard will use to render a configuration form to the user.
+     *
+     * This function is implemented as a typescript generic to facilitate type safety on just this function, if using the
+     * default generic definition of this class.
      */
     setSchema(schema) {
         this.parent.emit('set-schema', schema);
@@ -129,7 +135,7 @@ export class ConfigSDK {
  * Establish a connection to the Chec dashboard, and return an instance of the ConfigSDK class to provide API to
  * communicate with the dashboard.
  */
-export const createSDK = async () => {
+export async function createSDK() {
     // Create an event bus to handle events
     const bus = new EventBus();
     return new ConfigSDK(await new Postmate.Model({
@@ -138,4 +144,4 @@ export const createSDK = async () => {
             bus.trigger(event);
         }
     }), bus);
-};
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.4",
   "main": "index.js",
   "license": "BSD-3-Clause",
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "postmate": "^1.5.2",
     "typescript": "^4.4.4"


### PR DESCRIPTION
Rather than isolating just methods that update schema, we can also use this config type definition to document the type of the actual config provided by the SDK. A bit of an oversight that I didn't do this in the first place.