### PR TITLE
List types as dependency so consuming libraries don't get type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@types/postmate": "^1.5.2",
     "postmate": "^1.5.2",
     "typescript": "^4.4.4"
   },
   "devDependencies": {
-    "@types/postmate": "^1.5.2",
     "@types/resize-observer-browser": "^0.1.6"
   }
 }


### PR DESCRIPTION
Without this, consuming libraries aren't aware of Postman types and complain about calling `emit` that doesn't exist